### PR TITLE
PROJECT_APPS to INSTALLED_APPS

### DIFF
--- a/tiempo/__init__.py
+++ b/tiempo/__init__.py
@@ -5,4 +5,4 @@ TIEMPO_REGISTRY = {}
 RECENT_KEY = 'tiempo:recent_tasks'
 RESULT_PREFIX = 'tiempo:task_result'
 
-__version__ = "0.0.2"
+__version__ = "1.1.2"

--- a/tiempo/contrib/django/utils/loader.py
+++ b/tiempo/contrib/django/utils/loader.py
@@ -6,7 +6,7 @@ import importlib
 
 
 def auto_load_tasks():
-    for app in settings.PROJECT_APPS:
+    for app in settings.INSTALLED_APPS:
         module = importlib.import_module(app)
         try:
             importlib.import_module(app + '.tasks')


### PR DESCRIPTION
PROJECT_APPS is a reelio specific grouping of apps that contributes to Django's list of INSTALLED_APPS. Moving over to the generic django could save a lot of confusion when starting new projects that use tiempo.
@vepkenez yo man can you take a quick look at this and perhaps put it up on pypi.