### PR TITLE
REST Api, new disposition logic, lazy redis history queries

### DIFF
--- a/demo/tiempo_web/urls.py
+++ b/demo/tiempo_web/urls.py
@@ -1,9 +1,10 @@
-from django.conf.urls import include, url
+from django.conf.urls import include, url, patterns
 
-from tiempo.contrib.django_app.views import TiempoKiosk, TiempoHistory
+from tiempo.contrib.django_app.api import tiempo_api_router
+from tiempo.contrib.django_app.views import TiempoKiosk
 
-urlpatterns = [
-    url(r'^tiempo/', include('tiempo.contrib.django_app.urls')),
+urlpatterns = patterns('',
+    url(r'^tiempo/api/v1/', include(tiempo_api_router.urls)),
     url(r'^tiempo_kiosk', TiempoKiosk.as_view()),
-    url(r'^history', TiempoHistory.as_view()),
-]
+    # url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+)

--- a/runtests.py
+++ b/runtests.py
@@ -14,5 +14,51 @@ sys.path[:] = map(os.path.abspath, sys.path)
 sys.path.insert(0, os.path.abspath(os.getcwd()))
 sys.argv.append("tiempo/tests")
 
-from twisted.scripts.trial import run
-run()
+####
+
+# And now the django part.
+def run_django_tests():
+    import django
+    from django.conf import settings
+    from django.test.utils import get_runner
+
+    BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+    def run_settings():
+        settings.configure(
+            MIDDLEWARE_CLASSES=[],
+            ROOT_URLCONF='tiempo.contrib.django_app.urls',
+            TIEMPO_MANUAL=True,
+            INSTALLED_APPS=[
+                'tiempo.contrib.django_app',
+                'django.contrib.auth',
+                'django.contrib.contenttypes',
+                ],
+            SECRET_KEY = "LLAMAS",
+
+            DATABASES = {
+                'default': {
+                    'ENGINE': 'django.db.backends.sqlite3',
+                    'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+                }
+            },
+        )
+
+    run_settings()
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    django_test_results = test_runner.run_tests(["tiempo.contrib.django_app"])
+    return django_test_results
+
+
+try:
+    from twisted.scripts.trial import run
+    run()
+except SystemExit as finished_trial_run:
+    trial_failed = bool(finished_trial_run)
+finally:
+    django_test_results = run_django_tests()
+    django_tests_failed = bool(django_test_results)
+    sys.exit(trial_failed or django_tests_failed)

--- a/tiempo/__init__.py
+++ b/tiempo/__init__.py
@@ -6,6 +6,7 @@ TIEMPO_REGISTRY = {}
 # tiempo.runner.Runner add themselves as values for keys matching their groups.
 RUNNERS = {}
 
+
 def all_runners():
     all_runners = set()
     for runner_list in RUNNERS.values():
@@ -13,6 +14,16 @@ def all_runners():
             all_runners.add(runner)
 
     return all_runners
+
+
+def all_task_groups():
+    task_groups = set()
+    for runner_list in RUNNERS.values():
+        for runner in runner_list:
+            task_groups.update(runner.task_groups)
+    return task_groups
+
+
 
 
 REDIS_GROUP_NAMESPACE = 'tiempogroup'

--- a/tiempo/contrib/django_app/api/serializers.py
+++ b/tiempo/contrib/django_app/api/serializers.py
@@ -1,6 +1,22 @@
 from rest_framework import serializers
+from rest_framework.pagination import LimitOffsetPagination
+
+from tiempo.utils import JobReport
 
 
-class JobSerializer(serializers.Serializer):
+class JobsPaginator(LimitOffsetPagination):
 
-    status = serializers.CharField(max_length=200)
+    default_limit = 50
+    offset = 0
+
+    def __init__(self, *args, **kwargs):
+        super(JobsPaginator, self).__init__(*args, **kwargs)
+
+    def get_paginated_response(self, data):
+        return super(JobsPaginator, self).get_paginated_response(data)
+
+
+class JobSerializer(serializers.BaseSerializer):
+
+    def to_representation(self, obj):
+        return obj

--- a/tiempo/contrib/django_app/api/serializers.py
+++ b/tiempo/contrib/django_app/api/serializers.py
@@ -1,0 +1,6 @@
+from rest_framework import serializers
+
+
+class JobSerializer(serializers.Serializer):
+
+    status = serializers.CharField(max_length=200)

--- a/tiempo/contrib/django_app/api/urls.py
+++ b/tiempo/contrib/django_app/api/urls.py
@@ -1,0 +1,6 @@
+from rest_framework import routers
+
+from tiempo.contrib.django_app.views import TiempoHistoryViewSet
+
+tiempo_api_router = routers.DefaultRouter()
+tiempo_api_router.register(r'jobs', TiempoHistoryViewSet, "Job")

--- a/tiempo/contrib/django_app/api/urls.py
+++ b/tiempo/contrib/django_app/api/urls.py
@@ -1,6 +1,6 @@
 from rest_framework import routers
 
-from tiempo.contrib.django_app.views import TiempoHistoryViewSet
+from tiempo.contrib.django_app.api.views import TiempoHistoryViewSet
 
 tiempo_api_router = routers.DefaultRouter()
 tiempo_api_router.register(r'jobs', TiempoHistoryViewSet, "Job")

--- a/tiempo/contrib/django_app/api/views.py
+++ b/tiempo/contrib/django_app/api/views.py
@@ -1,0 +1,16 @@
+from rest_framework import viewsets
+from rest_framework.pagination import LimitOffsetPagination
+
+from tiempo.contrib.django_app.api.serializers import JobSerializer
+from tiempo.utils import JobReport
+
+
+class TiempoHistoryViewSet(viewsets.GenericViewSet):
+    pagination_class = LimitOffsetPagination
+    serializer_class = JobSerializer
+
+    def list(self, request):
+        jobs = JobReport()[:50]
+        return self.get_serializer(jobs, many=True)
+
+

--- a/tiempo/contrib/django_app/api/views.py
+++ b/tiempo/contrib/django_app/api/views.py
@@ -1,16 +1,16 @@
 from rest_framework import viewsets
-from rest_framework.pagination import LimitOffsetPagination
-
-from tiempo.contrib.django_app.api.serializers import JobSerializer
+from tiempo.contrib.django_app.api.serializers import JobSerializer, JobsPaginator
 from tiempo.utils import JobReport
 
 
 class TiempoHistoryViewSet(viewsets.GenericViewSet):
-    pagination_class = LimitOffsetPagination
+    pagination_class = JobsPaginator
     serializer_class = JobSerializer
+    queryset = JobReport()
 
     def list(self, request):
-        jobs = JobReport()[:50]
-        return self.get_serializer(jobs, many=True)
+        oaginated = self.paginate_queryset(self.get_queryset())
+        response = self.get_paginated_response(paginated)
+        return response
 
 

--- a/tiempo/contrib/django_app/appconfig.py
+++ b/tiempo/contrib/django_app/appconfig.py
@@ -4,6 +4,8 @@ import sys
 from tiempo.execution import thread_init
 from .utils.loader import auto_load_tasks
 from django.apps import AppConfig, apps
+from django.conf import settings
+
 
 class TiempoAppConfig(AppConfig):
     name = 'tiempo.contrib.django_app'
@@ -11,6 +13,8 @@ class TiempoAppConfig(AppConfig):
     path = os.path.dirname(__file__)
 
     def ready(self):
-        if not 'runtiempo' in sys.argv:
-            thread_init()
-            auto_load_tasks()
+        # TODO: I hate this.  I wish you had to do this manually.  - Justin
+        if not getattr(settings, 'TIEMPO_MANUAL', False):  # This is the maximum about of boolean consideration I assert if preferable for this condition.  - Justin
+            if not 'runtiempo' in sys.argv:  # This needs to be deprecated or refactored into a parsed argument.
+                thread_init()
+                auto_load_tasks()

--- a/tiempo/contrib/django_app/tests.py
+++ b/tiempo/contrib/django_app/tests.py
@@ -1,0 +1,15 @@
+from rest_framework.test import APISimpleTestCase
+
+from tiempo.tests.testing_utils import OneRunnerTestCase
+
+
+class JobHistoryApiTests(APISimpleTestCase, OneRunnerTestCase):
+
+    def test_51_jobs_paginated(self):
+        d = self.make_task_and_job_for_runner()
+
+        def api_examination(*args):
+            response = self.client.get('/api/v1/jobs/')
+            self.assertEqual(self.runner.current_job.uid, response.data['results'][0]['jobUid'])
+        d.addCallback(api_examination)
+        return d

--- a/tiempo/contrib/django_app/urls.py
+++ b/tiempo/contrib/django_app/urls.py
@@ -1,4 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import patterns, url, include
+
+from tiempo.contrib.django_app.api import tiempo_api_router
 from tiempo.contrib.django_app.views import TiempoKiosk
 
 urlpatterns = patterns(
@@ -7,5 +9,6 @@ urlpatterns = patterns(
     url(r'^kiosk/$', TiempoKiosk.as_view(), name="Tiempo Live Kiosk"),
     url(r'^history/$', TiempoKiosk.as_view(), name="Tiempo Task History"),
     url(r'^recent/$', 'recent_tasks', name='recent_tasks'),
-    url(r'^results/(?P<key>.+)', 'results', name='task_results')
+    url(r'^results/(?P<key>.+)', 'results', name='task_results'),
+    url(r'^api/v1/', include(tiempo_api_router.urls)),
 )

--- a/tiempo/insight.py
+++ b/tiempo/insight.py
@@ -18,11 +18,11 @@ def completed_jobs():
 
     try:
         jobs_list = [job for job in pipe.execute()]
-        insight_pipe_lock.release()
     except ResponseError:
-        insight_pipe_lock.release()
         # TODO: Announce that one of the result keys didn't point to a hash and that we don't know what to do about it.
         raise
+    finally:
+        insight_pipe_lock.release()
 
     uids = [key.split(":", 1)[1] for key in keys]
     jobs_and_keys_list = zip(uids, jobs_list)

--- a/tiempo/resource.py
+++ b/tiempo/resource.py
@@ -6,22 +6,21 @@ import json
 
 class TiempoMessageProtocol(MessageHandlerProtocol):
 
+    def jobs_to_announce(self):
+        # unsettings workaround
+        from tiempo.utils import JobReport
+
+        jobs = JobReport()[:50]
+        return jobs
+
     def dataReceived(self, data):
         # Unsettings workaround
-        from tiempo.utils import all_jobs
-        from tiempo.work import Job
-        from tiempo.conn import REDIS
         from tiempo.insight import completed_jobs
 
         if data == "updateJobs":
             # TODO: Better way to announce jobs
-            jobs_to_announce = OrderedDict()
-            jobs_dict = all_jobs([1, 2, 3])
-            for job_list in jobs_dict.values():
-                for job_string in job_list:
-                    job = Job.rehydrate(job_string)
-                    jobs_to_announce[job.uid] = job.serialize_to_dict()
-            hxdispatcher.send('all_tasks', {'jobs': jobs_to_announce})
+
+            hxdispatcher.send('all_tasks', {'jobs': self.jobs_to_announce()})
 
             # All completed jobs. # TODO: Move these things to their own place.
             all_completed = completed_jobs()

--- a/tiempo/tests/test_disposition.py
+++ b/tiempo/tests/test_disposition.py
@@ -1,0 +1,24 @@
+from tiempo.conn import REDIS
+from tiempo.tests.sample_tasks import some_callable
+from tiempo.tests.testing_utils import OneRunnerTestCase
+from tiempo.utils.premade_decorators import hourly_task
+
+
+class SuccessAndErrorsTests(OneRunnerTestCase):
+
+    def test_runner_success(self):
+        task = hourly_task(some_callable)
+        self.runner.current_job = task.just_spawn_job()
+        self.runner.announcer = self.runner.current_job.announcer
+        test_message = "this message was generated during the run."
+        self.runner.announcer.brief(test_message)
+        backend_response = self.runner.handle_success(None)
+        self.assertEqual(backend_response, [1, 1, True])  # Two 1s, each for pushing one entry to our sorted sets, and one True, for pushing the hash.
+
+        # So, at this point, we expect the success to have been saved in the backend.
+        # First, we use the key of the task to get the redis key to a hash of our results.
+        hash_key = REDIS.zrange("results:%s" % self.runner.current_job.task.key, 0, 0)[0]
+
+        # Now that we have the hash key, we can get the details of the run.
+        job_report = REDIS.hgetall(hash_key)
+        self.assertIn(test_message, job_report['result'])  # TODO: Why isn't this actually the string?  Why 'in'?

--- a/tiempo/tests/test_history.py
+++ b/tiempo/tests/test_history.py
@@ -1,0 +1,30 @@
+from tiempo.resource import TiempoMessageProtocol
+from tiempo.tests.testing_utils import OneRunnerTestCase
+from tiempo.utils import JobReport
+
+
+class JobHistoryTests(OneRunnerTestCase):
+
+    def test_jobs_reported_to_resource(self):
+        d = self.make_task_and_job_for_runner()
+
+        def see_how_jobs_are_announced_to_resource(*args):
+            job_list = JobReport()
+            jobs = job_list[0:10]
+            t = TiempoMessageProtocol()
+            j = t.jobs_to_announce()
+            self.assertEqual(jobs[0]['jobUid'], self.runner.current_job.uid)
+
+        d.addCallback(see_how_jobs_are_announced_to_resource)
+        return d
+
+    def test_lazy_evaulation(self):
+        d = self.make_task_and_job_for_runner()
+
+        def report_aftermath(*args):
+            job_list = JobReport()
+            jobs = job_list[0:10]
+            self.assertEqual(jobs[0]['jobUid'], self.runner.current_job.uid)
+
+        d.addCallback(report_aftermath)
+        return d

--- a/tiempo/tests/test_job_reporting.py
+++ b/tiempo/tests/test_job_reporting.py
@@ -6,6 +6,7 @@ from twisted.internet import reactor
 from tiempo import TIEMPO_REGISTRY
 from tiempo.conn import REDIS
 from tiempo.exceptions import JobDataError
+from tiempo.tests.testing_utils import OneRunnerTestCase
 from tiempo.work import Trabajo, Job
 from tiempo.tests.sample_tasks import some_callable
 from tiempo.insight import completed_jobs
@@ -13,7 +14,8 @@ from tiempo.runner import Runner
 
 import unittest
 
-class JobReportingTests(TestCase):
+
+class JobReportingTests(OneRunnerTestCase):
     """
     Tests for Job instances and report_handlers
     """
@@ -21,7 +23,6 @@ class JobReportingTests(TestCase):
 #    def __init__(self):
     decorated = Trabajo()(some_callable)
     simple_job = decorated.just_spawn_job()
-    runner = Runner(0, [1])
 
     def setup(self):
         TIEMPO_REGISTRY.clear()

--- a/tiempo/tests/testing_utils.py
+++ b/tiempo/tests/testing_utils.py
@@ -1,0 +1,26 @@
+from twisted.trial.unittest import TestCase
+from tiempo import TIEMPO_REGISTRY
+from tiempo.conn import REDIS
+from tiempo.runner import Runner
+from tiempo.tests.sample_tasks import some_callable
+from tiempo.utils.premade_decorators import hourly_task
+
+
+class OneRunnerTestCase(TestCase):
+
+    def setUp(self):
+        super(OneRunnerTestCase, self).setUp()
+        REDIS.flushall()
+        self.runner = Runner(0, [1])
+
+    def tearDown(self):
+        self.runner.shut_down()
+        REDIS.flushall()
+        TIEMPO_REGISTRY.clear()
+        super(OneRunnerTestCase, self).tearDown()
+
+    def make_task_and_job_for_runner(self):
+        task = hourly_task(some_callable)
+        job = task.spawn_job_and_run_soon()
+        d = self.runner.cycle()
+        return d

--- a/tiempo/tiempo_loop.py
+++ b/tiempo/tiempo_loop.py
@@ -26,6 +26,7 @@ logger = Logger()
 ps = REDIS.pubsub()
 update_queue = create_event_queue()
 
+
 def cycle():
     """This function runs in the event loop for tiempo"""
     # This loop does five things:
@@ -63,12 +64,14 @@ def let_runners_pick_up_queued_tasks():
             # Otherwise, it will have JUST PICKED UP A TASK.
             # If this is the case, it will have returned a Deferred.
             # We add our paths for success and failure here.
-            result.addCallbacks(runner.handle_success, runner.handle_error)
-            result.addCallback(cleanup, runner)
-            result.addErrback(cleanup_errors, runner)
+
+	    # TODO: Sort this out.
+            # result.addCallback(cleanup, runner)
+            # result.addErrback(cleanup_errors, runner)
+            pass
 
         runner.announce('runners')  # The runner may have changed state; announce it.
-    return
+    return result
 
 def queue_scheduled_tasks(backend_events):
     """


### PR DESCRIPTION
Tracks history using n+1 sorted sets, where n is the number of tasks in the TIEMPO_REGISTRY.
Splits the test suite into two which are one one after the other: non-django and then django.
Introduces testing_utils with a TestCase useful for testing Runners, Jobs, and Tasks.

Data model not compatible with previous version.  Flush redis before using.